### PR TITLE
Bug/2180-on-windows,-the-metadata-pop-ups-lose-focus-when-the-mouse-is-moved-on-the-canvas

### DIFF
--- a/OTAnalytics/plugin_ui/customtkinter_gui/frame_canvas.py
+++ b/OTAnalytics/plugin_ui/customtkinter_gui/frame_canvas.py
@@ -159,6 +159,9 @@ class CanvasEventHandler(EventHandler):
         self._observers.append(observer)
 
     def detach_observer(self, observer: CanvasObserver) -> None:
+        if self._canvas.focus_get() == self._canvas:
+            print("set focus to canvases masters master")
+            self._canvas.master.master.focus_set()
         self._observers.remove(observer)
 
     def _notify_observers(

--- a/OTAnalytics/plugin_ui/customtkinter_gui/frame_canvas.py
+++ b/OTAnalytics/plugin_ui/customtkinter_gui/frame_canvas.py
@@ -187,7 +187,6 @@ class CanvasEventHandler(EventHandler):
         self._notify_observers(event, LEAVE_CANVAS)
 
     def _on_mouse_enters_canvas(self, event: Any) -> None:
-        self._canvas.focus_set()
         self._notify_observers(event, ENTER_CANVAS)
 
     def _on_plus(self, event: Any) -> None:

--- a/OTAnalytics/plugin_ui/customtkinter_gui/frame_canvas.py
+++ b/OTAnalytics/plugin_ui/customtkinter_gui/frame_canvas.py
@@ -155,6 +155,7 @@ class CanvasEventHandler(EventHandler):
         self._canvas.bind("<Escape>", self._on_escape)
 
     def attach_observer(self, observer: CanvasObserver) -> None:
+        self._canvas.focus_set()
         self._observers.append(observer)
 
     def detach_observer(self, observer: CanvasObserver) -> None:

--- a/OTAnalytics/plugin_ui/customtkinter_gui/frame_filter.py
+++ b/OTAnalytics/plugin_ui/customtkinter_gui/frame_filter.py
@@ -215,6 +215,7 @@ class FilterTracksByDatePopup(CTkToplevel):
         self._get_widgets()
         self._place_widgets()
         self._bind_events()
+        self._set_focus()
 
         self._set_default_date_range(default_start_date, default_end_date)
 
@@ -283,6 +284,9 @@ class FilterTracksByDatePopup(CTkToplevel):
 
     def _bind_events(self) -> None:
         self.bind("<Escape>", self._close)
+
+    def _set_focus(self) -> None:
+        self.after(0, lambda: self.lift())
 
     def _close(self, _: Any = None) -> None:
         self.destroy()

--- a/OTAnalytics/plugin_ui/customtkinter_gui/line_section.py
+++ b/OTAnalytics/plugin_ui/customtkinter_gui/line_section.py
@@ -236,11 +236,11 @@ class SectionGeometryEditor(CanvasObserver):
             elif event_type == PLUS_KEYS:
                 self._add_knob(coordinate=coordinate)
             elif event_type in {RETURN_KEY, RIGHT_BUTTON_UP}:
+                self.detach_from(self._canvas.event_handler)
                 self._finish()
-                self.detach_from(self._canvas.event_handler)
             elif event_type == ESCAPE_KEY:
-                self._abort()
                 self.detach_from(self._canvas.event_handler)
+                self._abort()
         elif event_type == LEFT_KEY:
             self._shift_selected_knob_backward()
         elif event_type == RIGHT_KEY:
@@ -535,11 +535,11 @@ class SectionBuilder(SectionGeometryBuilderObserver, CanvasObserver):
         elif self.geometry_builder.number_of_coordinates() >= 2 and (
             event_type in {RIGHT_BUTTON_UP, RETURN_KEY}
         ):
+            self.detach_from(self._canvas.event_handler)
             self.geometry_builder.finish_building()
-            self.detach_from(self._canvas.event_handler)
         elif event_type == ESCAPE_KEY:
-            self.geometry_builder.abort()
             self.detach_from(self._canvas.event_handler)
+            self.geometry_builder.abort()
 
     def finish_building(
         self,

--- a/OTAnalytics/plugin_ui/customtkinter_gui/messagebox.py
+++ b/OTAnalytics/plugin_ui/customtkinter_gui/messagebox.py
@@ -34,7 +34,7 @@ class InfoBox(CTkToplevel):
         self.button_ok.grid(row=1, column=0, padx=PADX, pady=PADY, sticky=STICKY)
 
     def _set_focus(self) -> None:
-        self.button_ok.focus_set()
+        self.after(0, lambda: self.button_ok.focus_set())
 
     def _set_close_on_return_key(self) -> None:
         self.button_ok.bind("<Return>", self.close)

--- a/OTAnalytics/plugin_ui/customtkinter_gui/messagebox.py
+++ b/OTAnalytics/plugin_ui/customtkinter_gui/messagebox.py
@@ -34,6 +34,7 @@ class InfoBox(CTkToplevel):
         self.button_ok.grid(row=1, column=0, padx=PADX, pady=PADY, sticky=STICKY)
 
     def _set_focus(self) -> None:
+        self.attributes("-topmost", 1)
         self.after(0, lambda: self.button_ok.focus_set())
 
     def _set_close_on_return_key(self) -> None:

--- a/OTAnalytics/plugin_ui/customtkinter_gui/toplevel_flows.py
+++ b/OTAnalytics/plugin_ui/customtkinter_gui/toplevel_flows.py
@@ -83,6 +83,7 @@ class ToplevelFlows(CTkToplevel):
 
     def _set_focus(self) -> None:
         self.after(0, lambda: self.lift())
+        self.after(0, lambda: self.entry_distance.focus_set())
 
     def _set_close_on_return_key(self) -> None:
         self.entry_distance.bind("<Return>", self.close)

--- a/OTAnalytics/plugin_ui/customtkinter_gui/toplevel_flows.py
+++ b/OTAnalytics/plugin_ui/customtkinter_gui/toplevel_flows.py
@@ -82,7 +82,7 @@ class ToplevelFlows(CTkToplevel):
         self.geometry(f"+{x+10}+{y+10}")
 
     def _set_focus(self) -> None:
-        self.entry_distance.focus_set()
+        self.after(0, lambda: self.lift())
 
     def _set_close_on_return_key(self) -> None:
         self.entry_distance.bind("<Return>", self.close)

--- a/OTAnalytics/plugin_ui/customtkinter_gui/toplevel_sections.py
+++ b/OTAnalytics/plugin_ui/customtkinter_gui/toplevel_sections.py
@@ -72,7 +72,7 @@ class ToplevelSections(CTkToplevel):
         self.geometry(f"+{x+10}+{y+10}")
 
     def _set_focus(self) -> None:
-        self.entry_name.focus_set()
+        self.after(0, lambda: self.lift())
 
     def _set_close_on_return_key(self) -> None:
         self.entry_name.bind("<Return>", self.close)

--- a/OTAnalytics/plugin_ui/customtkinter_gui/toplevel_sections.py
+++ b/OTAnalytics/plugin_ui/customtkinter_gui/toplevel_sections.py
@@ -73,6 +73,7 @@ class ToplevelSections(CTkToplevel):
 
     def _set_focus(self) -> None:
         self.after(0, lambda: self.lift())
+        self.after(0, lambda: self.entry_name.focus_set())
 
     def _set_close_on_return_key(self) -> None:
         self.entry_name.bind("<Return>", self.close)


### PR DESCRIPTION
OP#2180

- [x] Test on Windows
- [x] Test on Mac
- [ ] Test on Linux