### PR TITLE
Added CachedPandasTrackProvider for caching the track DataFrame

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,6 @@ Thumbs.db
 
 # Vim
 .vim
+
+#profiling
+profiles/

--- a/OTAnalytics/plugin_ui/main_application.py
+++ b/OTAnalytics/plugin_ui/main_application.py
@@ -47,6 +47,7 @@ from OTAnalytics.plugin_parser.otvision_parser import (
     SimpleVideoParser,
 )
 from OTAnalytics.plugin_prototypes.track_visualization.track_viz import (
+    CachedPandasTrackProvider,
     MatplotlibTrackPlotter,
     PandasTrackProvider,
     PlotterPrototype,
@@ -197,7 +198,7 @@ class ApplicationStarter:
         state = TrackViewState()
         background_image_plotter = TrackBackgroundPlotter(state, datastore)
         dataframe_filter_builder = self._create_dataframe_filter_builder()
-        pandas_data_provider = PandasTrackProvider(
+        pandas_data_provider = CachedPandasTrackProvider(
             datastore, state, dataframe_filter_builder
         )
         track_geometry_plotter = self._create_track_geometry_plotter(


### PR DESCRIPTION
OP#2288

The CachedPandasTrackProvider extends PandasTrackProvider and caches the track DataFrame since its construction is costly. 
The cache is reset when changes to the track repository are observed.

Applied CachedPandasTrackProvider instead of PandasTrackProvider in main_application.
Added test to check the reset of cache works.

TODOs:
- [x] Future extension: add/remove specific tracks from dataframe when notify is called.