### PR TITLE
Print exception before displaying errorbox in gui

### DIFF
--- a/OTAnalytics/plugin_ui/customtkinter_gui/gui.py
+++ b/OTAnalytics/plugin_ui/customtkinter_gui/gui.py
@@ -49,10 +49,10 @@ class ModifiedCTk(CTk):
         self.quit()
 
     def report_callback_exception(self, exc: Any, val: Any, tb: Any) -> None:
+        traceback.print_exception(val)
         InfoBox(
             message=str(val), title="Error", initial_position=get_widget_position(self)
         )
-        traceback.print_exception(val)
 
 
 class TabviewInputFiles(CTkTabview):


### PR DESCRIPTION
... otherwise one has to close the errorbox before one can read the traceback in the terminal