### PR TITLE
feature/2071-set-(05,-05)-as-default-offset-for-plotting-tracks-on-the-canvas

### DIFF
--- a/OTAnalytics/application/state.py
+++ b/OTAnalytics/application/state.py
@@ -203,7 +203,7 @@ class TrackViewState:
         self.background_image = ObservableOptionalProperty[TrackImage]()
         self.show_tracks = ObservableOptionalProperty[bool]()
         self.track_offset = ObservableOptionalProperty[RelativeOffsetCoordinate](
-            RelativeOffsetCoordinate(0, 0)
+            RelativeOffsetCoordinate(0.5, 0.5)
         )
         self.filter_element = ObservableProperty[FilterElement](
             FilterElement(DateRange(None, None), None)


### PR DESCRIPTION
OP#2071