### PR TITLE
bug/2599-gui-crashes-before-completely-loading-tracks-on-windows

### DIFF
--- a/OTAnalytics/plugin_ui/customtkinter_gui/dummy_viewmodel.py
+++ b/OTAnalytics/plugin_ui/customtkinter_gui/dummy_viewmodel.py
@@ -295,6 +295,7 @@ class DummyViewModel(
             initial_position=self._window.get_position(),
         )
         self._application.intersect_tracks_with_sections()
+        start_msg_popup.update_message(message="Creating events completed")
         start_msg_popup.close()
 
     def notify_sections(self, sections: list[SectionId]) -> None:


### PR DESCRIPTION
OP#2599

Re-adds updating a message in a popup in the viewmodel´s intersect_tracks_with_sections method (partly reverts #278 and OP##2538)