### PR TITLE
Feature/2452 clear section and flow repository when loading an otflow file

### DIFF
--- a/OTAnalytics/application/application.py
+++ b/OTAnalytics/application/application.py
@@ -25,6 +25,7 @@ from OTAnalytics.application.use_cases.event_repository import ClearEventReposit
 from OTAnalytics.application.use_cases.export_events import EventListExporter
 from OTAnalytics.application.use_cases.flow_repository import AddFlow
 from OTAnalytics.application.use_cases.generate_flows import GenerateFlows
+from OTAnalytics.application.use_cases.load_otflow import LoadOtflow
 from OTAnalytics.application.use_cases.section_repository import AddSection
 from OTAnalytics.application.use_cases.track_repository import GetAllTrackFiles
 from OTAnalytics.application.use_cases.update_project import ProjectUpdater
@@ -79,6 +80,10 @@ class OTAnalyticsApplication:
         create_intersection_events: CreateIntersectionEvents,
         export_counts: ExportCounts,
         create_events: CreateEvents,
+        load_otflow: LoadOtflow,
+        add_section: AddSection,
+        add_flow: AddFlow,
+        clear_event_repository: ClearEventRepository,
     ) -> None:
         self._datastore: Datastore = datastore
         self.track_state: TrackState = track_state
@@ -88,20 +93,19 @@ class OTAnalyticsApplication:
         self._tracks_metadata = tracks_metadata
         self.action_state = action_state
         self._filter_element_setting_restorer = filter_element_setting_restorer
-        self._add_section = AddSection(self._datastore._section_repository)
-        self._add_flow = AddFlow(self._datastore._flow_repository)
+        self._add_section = add_section
+        self._add_flow = add_flow
         self._get_all_track_files = get_all_track_files
         self._generate_flows = generate_flows
         self._create_intersection_events = create_intersection_events
-        self._clear_event_repository = ClearEventRepository(
-            self._datastore._event_repository
-        )
+        self._clear_event_repository = clear_event_repository
         self._export_counts = export_counts
         self._project_updater = ProjectUpdater(datastore)
         self._save_otconfig = SaveOtconfig(
             datastore, config_parser=datastore._config_parser
         )
         self._create_events = create_events
+        self._load_otflow = load_otflow
 
     def connect_observers(self) -> None:
         """
@@ -186,7 +190,7 @@ class OTAnalyticsApplication:
         return self._add_flow.is_flow_name_valid(flow_name)
 
     def add_flow(self, flow: Flow) -> None:
-        self._add_flow.add(flow)
+        self._add_flow(flow)
 
     def generate_flows(self) -> None:
         self._generate_flows.generate()
@@ -235,7 +239,7 @@ class OTAnalyticsApplication:
         Args:
             sections_file (Path): file in sections format
         """
-        self._datastore.load_otflow(file=sections_file)
+        self._load_otflow(sections_file)
 
     def is_flow_using_section(self, section: SectionId) -> bool:
         """
@@ -286,7 +290,7 @@ class OTAnalyticsApplication:
         Args:
             section (Section): section to add
         """
-        self._add_section.add(section)
+        self._add_section(section)
 
     def remove_section(self, section: SectionId) -> None:
         """

--- a/OTAnalytics/application/datastore.py
+++ b/OTAnalytics/application/datastore.py
@@ -370,17 +370,6 @@ class Datastore:
         """Delete all tracks in repository."""
         self._track_repository.clear()
 
-    def load_otflow(self, file: Path) -> None:
-        """
-        Load sections and flows from the given files and store them in the repositories.
-
-        Args:
-            file (Path): file to load sections and flows from
-        """
-        sections, flows = self._flow_parser.parse(file)
-        self._section_repository.add_all(sections)
-        self._flow_repository.add_all(flows)
-
     def save_flow_file(self, file: Path) -> None:
         """
         Save the flows and sections from the repositories into a file.

--- a/OTAnalytics/application/use_cases/flow_repository.py
+++ b/OTAnalytics/application/use_cases/flow_repository.py
@@ -1,24 +1,43 @@
-from OTAnalytics.domain.flow import Flow, FlowRepository
+from OTAnalytics.domain.flow import Flow, FlowId, FlowRepository
 
 
 class FlowAlreadyExists(Exception):
     pass
 
 
+class FlowIdAlreadyExists(Exception):
+    pass
+
+
 class AddFlow:
     """
     Add a single flow to the repository.
+
+    Args:
+        flow_repository (FlowRepository): the flow repository to add the flow to.
     """
 
     def __init__(self, flow_repository: FlowRepository) -> None:
         self._flow_repository = flow_repository
 
-    def add(self, flow: Flow) -> None:
+    def __call__(self, flow: Flow) -> None:
+        """Adds flow to the flow repository.
+
+        Raises:
+            FlowAlreadyExists: if flow name already exists in repository.
+            FlowIdAlreadyExists: if flow id already exists in repository.
+
+        Args:
+            flow (Flow): the flow to be added.
+        """
         if not self.is_flow_name_valid(flow.name):
             raise FlowAlreadyExists(
                 f"A flow with the name {flow.name} already exists. "
                 "Choose another name."
             )
+        if not self.is_flow_id_valid(flow.id):
+            raise FlowIdAlreadyExists(f"A flow with id {flow.id} already exists.")
+
         self._flow_repository.add(flow)
 
     def is_flow_name_valid(self, flow_name: str) -> bool:
@@ -28,3 +47,21 @@ class AddFlow:
             stored_flow.name != flow_name
             for stored_flow in self._flow_repository.get_all()
         )
+
+    def is_flow_id_valid(self, flow_id: FlowId) -> bool:
+        return not (flow_id in self._flow_repository.get_flow_ids())
+
+
+class ClearFlows:
+    """Clear the flow repository.
+
+    Args:
+        flow_repository: the flow repository to be cleared.
+    """
+
+    def __init__(self, flow_repository: FlowRepository) -> None:
+        self._flow_repository = flow_repository
+
+    def __call__(self) -> None:
+        """Clear the flow repository."""
+        self._flow_repository.clear()

--- a/OTAnalytics/application/use_cases/load_otflow.py
+++ b/OTAnalytics/application/use_cases/load_otflow.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+from typing import Iterable
+
+from OTAnalytics.application.datastore import FlowParser
+from OTAnalytics.application.use_cases.event_repository import ClearEventRepository
+from OTAnalytics.application.use_cases.flow_repository import (
+    AddFlow,
+    ClearFlows,
+    FlowAlreadyExists,
+)
+from OTAnalytics.application.use_cases.section_repository import (
+    AddSection,
+    ClearSections,
+    SectionAlreadyExists,
+)
+from OTAnalytics.domain.flow import Flow
+from OTAnalytics.domain.section import Section
+
+
+class UnableToLoadFlowFile(Exception):
+    pass
+
+
+class LoadOtflow:
+    """
+    Load sections and flows from the given files and store them in the repositories.
+
+    Args:
+        clear_sections (ClearSections): use case to clear section repository.
+        clear_flows (ClearFlows): use case to clear flow repository.
+        clear_events (ClearEventRepository): use case to clear event repository.
+        flow_parser (FlowParser): to parse sections and flows from file.
+        add_section (AddSection): use case to add sections to section repository.
+        add_flow (AddFlow): use case to add flows to flow repository.
+    """
+
+    def __init__(
+        self,
+        clear_sections: ClearSections,
+        clear_flows: ClearFlows,
+        clear_events: ClearEventRepository,
+        flow_parser: FlowParser,
+        add_section: AddSection,
+        add_flow: AddFlow,
+    ) -> None:
+        self._clear_sections = clear_sections
+        self._clear_flows = clear_flows
+        self._clear_events = clear_events
+        self._flow_parser = flow_parser
+        self._add_section = add_section
+        self._add_flow = add_flow
+
+    def __call__(self, file: Path) -> None:
+        """
+        Load sections and flows from the given files and store them in the repositories.
+
+        Args:
+            file (Path): file to load sections and flows from.
+        """
+        self._clear_repositories()
+
+        sections, flows = self._flow_parser.parse(file)
+        try:
+            self._add_sections(sections)
+            self._add_flows(flows)
+
+        except (SectionAlreadyExists, FlowAlreadyExists) as cause:
+            self._clear_repositories()
+            raise UnableToLoadFlowFile(
+                "Error while loading otflow file. Abort loading!"
+            ) from cause
+
+    def _clear_repositories(self) -> None:
+        self._clear_events()
+        self._clear_sections()
+        self._clear_flows()
+
+    def _add_sections(self, sections: Iterable[Section]) -> None:
+        for section in sections:
+            self._add_section.__call__(section)
+
+    def _add_flows(self, flows: Iterable[Flow]) -> None:
+        for flow in flows:
+            self._add_flow.__call__(flow)

--- a/OTAnalytics/application/use_cases/section_repository.py
+++ b/OTAnalytics/application/use_cases/section_repository.py
@@ -7,6 +7,10 @@ class SectionAlreadyExists(Exception):
     pass
 
 
+class SectionIdAlreadyExists(Exception):
+    pass
+
+
 class GetAllSections:
     """Get all sections from the repository."""
 
@@ -46,16 +50,33 @@ class GetSectionsById:
 class AddSection:
     """
     Add a single section to the repository.
+
+    Args:
+        section_repository (SectionRepository): the section repository to add the
+            section to.
     """
 
     def __init__(self, section_repository: SectionRepository) -> None:
         self._section_repository = section_repository
 
-    def add(self, section: Section) -> None:
+    def __call__(self, section: Section) -> None:
+        """Adds section to the section repository.
+
+        Raises:
+            SectionAlreadyExists: if section name already exists in repository.
+            SectionIdAlreadyExists: if section id already exists in repository.
+
+        Args:
+            section (Section): the section to be added.
+        """
         if not self.is_section_name_valid(section.name):
             raise SectionAlreadyExists(
                 f"A section with the name {section.name} already exists. "
                 "Choose another name."
+            )
+        if not self.is_section_id_valid(section.id):
+            raise SectionIdAlreadyExists(
+                f"A section with id {section.id} already exists."
             )
         self._section_repository.add(section)
 
@@ -66,3 +87,20 @@ class AddSection:
             stored_section.name != section_name
             for stored_section in self._section_repository.get_all()
         )
+
+    def is_section_id_valid(self, section_id: SectionId) -> bool:
+        return not (section_id in self._section_repository.get_section_ids())
+
+
+class ClearSections:
+    """Clear the section repository.
+
+    Args:
+        section_repository: the section repository to be cleared.
+    """
+
+    def __init__(self, section_repository: SectionRepository):
+        self._section_repository = section_repository
+
+    def __call__(self) -> None:
+        self._section_repository.clear()

--- a/OTAnalytics/domain/flow.py
+++ b/OTAnalytics/domain/flow.py
@@ -226,3 +226,11 @@ class FlowRepository:
 
     def get_all(self) -> list[Flow]:
         return list(self._flows.values())
+
+    def get_flow_ids(self) -> Iterable[FlowId]:
+        """Get all flow ids used in repository.
+
+        Returns:
+            Iterable[FlowId]: the flow ids.
+        """
+        return self._flows.keys()

--- a/OTAnalytics/domain/section.py
+++ b/OTAnalytics/domain/section.py
@@ -388,6 +388,14 @@ class SectionRepository:
         """
         return self._sections.get(id)
 
+    def get_section_ids(self) -> Iterable[SectionId]:
+        """Get all section ids used in repository.
+
+        Returns:
+            Iterable[SectionId]: the section ids.
+        """
+        return self._sections.keys()
+
     def remove(self, section: SectionId) -> None:
         """Remove section from the repository.
 

--- a/OTAnalytics/plugin_parser/otvision_parser.py
+++ b/OTAnalytics/plugin_parser/otvision_parser.py
@@ -420,6 +420,8 @@ class InvalidSectionData(Exception):
     This exception indicates invalid data when parsing a section file.
     """
 
+    pass
+
 
 class OtFlowParser(FlowParser):
     """

--- a/OTAnalytics/plugin_ui/cli.py
+++ b/OTAnalytics/plugin_ui/cli.py
@@ -147,7 +147,7 @@ class OTAnalyticsCli:
     def _add_sections(self, sections: Iterable[Section]) -> None:
         """Add sections to section repository."""
         for section in sections:
-            self._add_section.add(section)
+            self._add_section(section)
 
     def _parse_tracks(self, track_file: Path) -> Iterable[Track]:
         return self._track_parser.parse(track_file)

--- a/OTAnalytics/plugin_ui/customtkinter_gui/dummy_viewmodel.py
+++ b/OTAnalytics/plugin_ui/customtkinter_gui/dummy_viewmodel.py
@@ -575,6 +575,17 @@ class DummyViewModel(
             raise ValueError("Configuration file to load has unknown file extension")
 
     def _load_otflow(self, otflow_file: Path) -> None:
+        proceed = InfoBox(
+            message=(
+                "This will load a stored otflow configuration from file. \n"
+                "All configured sections and flows will be removed before "
+                "loading."
+            ),
+            initial_position=self._get_window_position(),
+            show_cancel=True,
+        )
+        if proceed.canceled:
+            return
         logger().info(f"otflow file to load: {otflow_file}")
         self._application.load_otflow(sections_file=Path(otflow_file))
         self.set_selected_section_ids([])

--- a/OTAnalytics/plugin_ui/main_application.py
+++ b/OTAnalytics/plugin_ui/main_application.py
@@ -49,6 +49,7 @@ from OTAnalytics.application.use_cases.event_repository import (
     AddEvents,
     ClearEventRepository,
 )
+from OTAnalytics.application.use_cases.flow_repository import AddFlow, ClearFlows
 from OTAnalytics.application.use_cases.generate_flows import (
     ArrowFlowNameGenerator,
     CrossProductFlowGenerator,
@@ -64,8 +65,10 @@ from OTAnalytics.application.use_cases.highlight_intersections import (
     TracksNotIntersectingSelection,
     TracksOverlapOccurrenceWindow,
 )
+from OTAnalytics.application.use_cases.load_otflow import LoadOtflow
 from OTAnalytics.application.use_cases.section_repository import (
     AddSection,
+    ClearSections,
     GetSectionsById,
 )
 from OTAnalytics.application.use_cases.track_repository import (
@@ -230,9 +233,14 @@ class ApplicationStarter:
             section_repository, flow_repository
         )
         add_events = AddEvents(event_repository)
+        clear_events = ClearEventRepository(event_repository)
         get_all_tracks = GetAllTracks(track_repository)
+        clear_sections = ClearSections(section_repository)
+        clear_flows = ClearFlows(flow_repository)
+        add_section = AddSection(section_repository)
+        add_flow = AddFlow(flow_repository)
         create_events = self._create_use_case_create_events(
-            section_repository, event_repository, get_all_tracks, add_events
+            section_repository, clear_events, get_all_tracks, add_events
         )
         intersect_tracks_with_sections = (
             self._create_use_case_create_intersection_events(
@@ -241,6 +249,14 @@ class ApplicationStarter:
         )
         export_counts = self._create_export_counts(
             event_repository, flow_repository, track_repository
+        )
+        load_otflow = self._create_use_case_load_otflow(
+            clear_sections,
+            clear_flows,
+            clear_events,
+            datastore._flow_parser,
+            add_section,
+            add_flow,
         )
         application = OTAnalyticsApplication(
             datastore=datastore,
@@ -256,6 +272,10 @@ class ApplicationStarter:
             create_intersection_events=intersect_tracks_with_sections,
             export_counts=export_counts,
             create_events=create_events,
+            load_otflow=load_otflow,
+            add_section=add_section,
+            add_flow=add_flow,
+            clear_event_repository=clear_events,
         )
         application.connect_clear_event_repository_observer()
         flow_parser: FlowParser = application._datastore._flow_parser
@@ -291,8 +311,9 @@ class ApplicationStarter:
         add_section = AddSection(section_repository)
         add_events = AddEvents(event_repository)
         get_all_tracks = GetAllTracks(track_repository)
+        clear_events = ClearEventRepository(event_repository)
         create_events = self._create_use_case_create_events(
-            section_repository, event_repository, get_all_tracks, add_events
+            section_repository, clear_events, get_all_tracks, add_events
         )
         add_all_tracks = AddAllTracks(track_repository)
         clear_all_tracks = ClearAllTracks(track_repository)
@@ -808,12 +829,11 @@ class ApplicationStarter:
     def _create_use_case_create_events(
         self,
         section_repository: SectionRepository,
-        event_repository: EventRepository,
+        clear_events: ClearEventRepository,
         get_all_tracks: GetAllTracks,
         add_events: AddEvents,
     ) -> CreateEvents:
         run_intersect = self._create_intersect(get_all_tracks)
-        clear_event_repository = ClearEventRepository(event_repository)
         create_intersection_events = SimpleCreateIntersectionEvents(
             run_intersect, section_repository, add_events
         )
@@ -822,7 +842,7 @@ class ApplicationStarter:
             get_all_tracks, scene_action_detector, add_events
         )
         return CreateEvents(
-            clear_event_repository, create_intersection_events, create_scene_events
+            clear_events, create_intersection_events, create_scene_events
         )
 
     def _create_tracks_intersecting_sections(
@@ -832,4 +852,22 @@ class ApplicationStarter:
     ) -> TracksIntersectingSections:
         return SimpleTracksIntersectingSections(
             get_all_tracks, intersect_implementation
+        )
+
+    @staticmethod
+    def _create_use_case_load_otflow(
+        clear_sections: ClearSections,
+        clear_flows: ClearFlows,
+        clear_events: ClearEventRepository,
+        flow_parser: FlowParser,
+        add_section: AddSection,
+        add_flow: AddFlow,
+    ) -> LoadOtflow:
+        return LoadOtflow(
+            clear_sections,
+            clear_flows,
+            clear_events,
+            flow_parser,
+            add_section,
+            add_flow,
         )

--- a/tests/OTAnalytics/application/use_cases/test_flow_repository.py
+++ b/tests/OTAnalytics/application/use_cases/test_flow_repository.py
@@ -2,34 +2,72 @@ from unittest.mock import Mock, call
 
 import pytest
 
-from OTAnalytics.application.use_cases.flow_repository import AddFlow, FlowAlreadyExists
-from OTAnalytics.domain.flow import Flow, FlowRepository
+from OTAnalytics.application.use_cases.flow_repository import (
+    AddFlow,
+    FlowAlreadyExists,
+    FlowIdAlreadyExists,
+)
+from OTAnalytics.domain.flow import Flow, FlowId, FlowRepository
+
+
+@pytest.fixture
+def first_flow() -> Mock:
+    flow = Mock(spec=Flow)
+    flow.id = FlowId("1")
+    flow.name = "first"
+    return flow
+
+
+@pytest.fixture
+def second_flow() -> Mock:
+    flow = Mock(spec=Flow)
+    flow.id = FlowId("2")
+    flow.name = "second"
+    return flow
+
+
+@pytest.fixture
+def flow_repository(first_flow: Mock) -> Mock:
+    repository = Mock(spec=FlowRepository)
+    repository.get_all.return_value = [first_flow]
+    repository.get_flow_ids.return_value = {first_flow.id}
+    return repository
+
+
+class FlowIdAlreaydyExists:
+    pass
 
 
 class TestAddFlow:
-    def test_add_flow_with_different_names(self) -> None:
-        some_flow = Mock(spec=Flow)
-        some_flow.name = "some"
-        other_flow = Mock(spec=Flow)
-        other_flow.name = "other"
-        flow_repository = Mock(spec=FlowRepository)
-        flow_repository.get_all.return_value = [some_flow]
+    def test_add_flow_with_different_names(
+        self, flow_repository: Mock, first_flow: Mock, second_flow: Mock
+    ) -> None:
         use_case = AddFlow(flow_repository)
 
-        use_case.add(other_flow)
+        use_case(second_flow)
 
         assert flow_repository.add.call_args_list == [
-            call(other_flow),
+            call(second_flow),
         ]
+        flow_repository.get_flow_ids.assert_called_once()
 
-    def test_add_flow_with_same_names(self) -> None:
-        some_flow = Mock(spec=Flow)
-        some_flow.name = "some"
-        other_flow = Mock(spec=Flow)
-        other_flow.name = "some"
-        flow_repository = Mock(spec=FlowRepository)
-        flow_repository.get_all.return_value = [some_flow]
+    def test_add_flow_with_same_names(
+        self, flow_repository: Mock, first_flow: Mock
+    ) -> None:
+        flow_repository.get_all.return_value = [first_flow]
         use_case = AddFlow(flow_repository)
 
         with pytest.raises(FlowAlreadyExists):
-            use_case.add(other_flow)
+            use_case(first_flow)
+
+    def test_add_flow_with_existing_id(
+        self, first_flow: Mock, flow_repository: Mock
+    ) -> None:
+        new_section = Mock(spec=Flow)
+        new_section.id = first_flow.id
+        new_section.name = "New"
+
+        use_case = AddFlow(flow_repository)
+
+        with pytest.raises(FlowIdAlreadyExists):
+            use_case(new_section)

--- a/tests/OTAnalytics/application/use_cases/test_load_otflow.py
+++ b/tests/OTAnalytics/application/use_cases/test_load_otflow.py
@@ -1,0 +1,133 @@
+from pathlib import Path
+from typing import TypedDict
+from unittest.mock import Mock, call
+
+import pytest
+
+from OTAnalytics.application.datastore import FlowParser
+from OTAnalytics.application.use_cases.event_repository import ClearEventRepository
+from OTAnalytics.application.use_cases.flow_repository import (
+    AddFlow,
+    ClearFlows,
+    FlowAlreadyExists,
+)
+from OTAnalytics.application.use_cases.load_otflow import (
+    LoadOtflow,
+    UnableToLoadFlowFile,
+)
+from OTAnalytics.application.use_cases.section_repository import (
+    AddSection,
+    ClearSections,
+    SectionAlreadyExists,
+)
+from OTAnalytics.domain.flow import Flow
+from OTAnalytics.domain.section import Section
+
+
+class MockDependencies(TypedDict):
+    clear_sections: Mock
+    clear_flows: Mock
+    clear_events: Mock
+    flow_parser: Mock
+    add_section: Mock
+    add_flow: Mock
+
+
+class TestLoadOtflow:
+    @pytest.fixture
+    def mock_first_section(self) -> Mock:
+        return Mock(spec=Section)
+
+    @pytest.fixture
+    def mock_second_section(self) -> Mock:
+        return Mock(spec=Section)
+
+    @pytest.fixture
+    def mock_flow(self) -> Mock:
+        return Mock(spec=Flow)
+
+    @pytest.fixture
+    def mock_deps(
+        self, mock_first_section: Mock, mock_second_section: Mock, mock_flow: Mock
+    ) -> MockDependencies:
+        clear_sections = Mock(spec=ClearSections)
+        clear_flows = Mock(spec=ClearFlows)
+        clear_events = Mock(spec=ClearEventRepository)
+
+        flow_parser = Mock(spec=FlowParser)
+        flow_parser.parse.return_value = (
+            [mock_first_section, mock_second_section],
+            [mock_flow],
+        )
+
+        add_section = Mock(spec=AddSection)
+        add_flow = Mock(spec=AddFlow)
+        return {
+            "clear_sections": clear_sections,
+            "clear_flows": clear_flows,
+            "clear_events": clear_events,
+            "flow_parser": flow_parser,
+            "add_section": add_section,
+            "add_flow": add_flow,
+        }
+
+    def test_load_flow_file(
+        self,
+        mock_deps: MockDependencies,
+        mock_first_section: Mock,
+        mock_second_section: Mock,
+        mock_flow: Mock,
+    ) -> None:
+        load_flow_file = LoadOtflow(**mock_deps)
+
+        otflow_file = Mock(spec=Path)
+        load_flow_file(otflow_file)
+
+        mock_deps["flow_parser"].parse.assert_called_once_with(otflow_file)
+        assert mock_deps["add_section"].call_args_list == [
+            call(mock_first_section),
+            call(mock_second_section),
+        ]
+        assert mock_deps["add_flow"].call_args_list == [call(mock_flow)]
+        mock_deps["clear_events"].assert_called_once()
+        mock_deps["clear_flows"].assert_called_once()
+        mock_deps["clear_sections"].assert_called_once()
+
+    def test_load_flow_file_invalid_section_file(
+        self, mock_deps: MockDependencies, mock_first_section: Mock
+    ) -> None:
+        mock_deps["add_section"].side_effect = SectionAlreadyExists
+        load_flow_file = LoadOtflow(**mock_deps)
+        otflow_file = Mock(spec=Path)
+
+        with pytest.raises((SectionAlreadyExists, UnableToLoadFlowFile)):
+            load_flow_file(otflow_file)
+
+        mock_deps["add_section"].assert_called_once_with(mock_first_section)
+        mock_deps["add_flow"].assert_not_called()
+        assert mock_deps["clear_sections"].call_count == 2
+        assert mock_deps["clear_flows"].call_count == 2
+        assert mock_deps["clear_events"].call_count == 2
+
+    def test_load_flow_file_invalid_flow_file(
+        self,
+        mock_deps: MockDependencies,
+        mock_first_section: Mock,
+        mock_second_section: Mock,
+        mock_flow: Mock,
+    ) -> None:
+        mock_deps["add_flow"].side_effect = FlowAlreadyExists
+        load_flow_file = LoadOtflow(**mock_deps)
+        otflow_file = Mock(spec=Path)
+
+        with pytest.raises((FlowAlreadyExists, UnableToLoadFlowFile)):
+            load_flow_file(otflow_file)
+
+        assert mock_deps["add_section"].call_args_list == [
+            call(mock_first_section),
+            call(mock_second_section),
+        ]
+        mock_deps["add_flow"].assert_called_once_with(mock_flow)
+        assert mock_deps["clear_sections"].call_count == 2
+        assert mock_deps["clear_flows"].call_count == 2
+        assert mock_deps["clear_events"].call_count == 2

--- a/tests/OTAnalytics/application/use_cases/test_section_repository.py
+++ b/tests/OTAnalytics/application/use_cases/test_section_repository.py
@@ -7,6 +7,7 @@ from OTAnalytics.application.use_cases.section_repository import (
     GetAllSections,
     GetSectionsById,
     SectionAlreadyExists,
+    SectionIdAlreadyExists,
 )
 from OTAnalytics.domain.section import Section, SectionId, SectionRepository
 
@@ -31,6 +32,7 @@ def section_south() -> Mock:
 def section_repository(section_north: Mock) -> Mock:
     repository = Mock(spec=SectionRepository)
     repository.get_all.return_value = [section_north]
+    repository.get_section_ids.return_value = {section_north.id}
     return repository
 
 
@@ -66,11 +68,12 @@ class TestAddSection:
     ) -> None:
         use_case = AddSection(section_repository)
 
-        use_case.add(section_south)
+        use_case.__call__(section_south)
 
         assert section_repository.add.call_args_list == [
             call(section_south),
         ]
+        section_repository.get_section_ids.assert_called_once()
 
     def test_add_section_with_same_names(
         self,
@@ -83,4 +86,18 @@ class TestAddSection:
         use_case = AddSection(section_repository)
 
         with pytest.raises(SectionAlreadyExists):
-            use_case.add(section_south)
+            use_case(section_south)
+
+    def test_add_section_with_existing_id(
+        self,
+        section_north: Mock,
+        section_repository: Mock,
+    ) -> None:
+        new_section = Mock(spec=Section)
+        new_section.id = section_north.id
+        new_section.name = "New"
+
+        use_case = AddSection(section_repository)
+
+        with pytest.raises(SectionIdAlreadyExists):
+            use_case(new_section)

--- a/tests/OTAnalytics/domain/test_flow.py
+++ b/tests/OTAnalytics/domain/test_flow.py
@@ -130,3 +130,13 @@ class TestFlowRepository:
         assert using_flow_end_section == [flow]
         assert using_other_start_section == [other_flow]
         assert using_other_end_section == [other_flow]
+
+    def test_get_flow_ids(self) -> None:
+        flow_id = FlowId("North -> South")
+        flow = Mock(spec=Flow)
+        flow.id = flow_id
+
+        repository = FlowRepository()
+        repository.add(flow)
+        result = repository.get_flow_ids()
+        assert list(result) == [flow_id]

--- a/tests/OTAnalytics/domain/test_section.py
+++ b/tests/OTAnalytics/domain/test_section.py
@@ -484,3 +484,13 @@ class TestSectionRepository:
             call([section_id_north, section_id_south]),
             call([]),
         ]
+
+    def test_get_section_ids(self) -> None:
+        section_id = SectionId("North")
+        section = Mock(spec=Section)
+        section.id = section_id
+
+        repository = SectionRepository()
+        repository.add(section)
+        result = repository.get_section_ids()
+        assert list(result) == [section_id]


### PR DESCRIPTION
* extract loading an otflow as a separate use case
* remove `load_otflow` from `Datastore`
* check that section id and name are unique before adding them to repository
* check that flow id and name are unique before adding them to repository
* warn user that currently created sections and flows will be deleted when loading otflow.

OP#2452