### PR TITLE
feature/2739-create-events-and-assign-tracks-to-flows-automatically-before-counting-flows

### DIFF
--- a/OTAnalytics/application/analysis/traffic_counting.py
+++ b/OTAnalytics/application/analysis/traffic_counting.py
@@ -10,6 +10,7 @@ from OTAnalytics.application.analysis.traffic_counting_specification import (
     ExportFormat,
     ExportSpecificationDto,
 )
+from OTAnalytics.application.use_cases.create_events import CreateEvents
 from OTAnalytics.domain.event import Event, EventRepository
 from OTAnalytics.domain.flow import Flow, FlowRepository
 from OTAnalytics.domain.section import SectionId
@@ -822,12 +823,14 @@ class ExportTrafficCounting(ExportCounts):
         self,
         event_repository: EventRepository,
         flow_repository: FlowRepository,
+        create_events: CreateEvents,
         assigner: RoadUserAssigner,
         tagger_factory: TaggerFactory,
         exporter_factory: ExporterFactory,
     ) -> None:
         self._event_repository = event_repository
         self._flow_repository = flow_repository
+        self._create_events = create_events
         self._assigner = assigner
         self._tagger_factory = tagger_factory
         self._exporter_factory = exporter_factory
@@ -839,6 +842,7 @@ class ExportTrafficCounting(ExportCounts):
         Args:
             specification (CountingSpecificationDto): specification of the export
         """
+        self._create_events()
         events = self._event_repository.get_all()
         flows = self._flow_repository.get_all()
         assigned_flows = self._assigner.assign(events, flows)

--- a/OTAnalytics/plugin_ui/main_application.py
+++ b/OTAnalytics/plugin_ui/main_application.py
@@ -293,7 +293,7 @@ class ApplicationStarter:
             )
         )
         export_counts = self._create_export_counts(
-            event_repository, flow_repository, track_repository
+            event_repository, flow_repository, track_repository, create_events
         )
         load_otflow = self._create_use_case_load_otflow(
             clear_all_sections,
@@ -441,7 +441,7 @@ class ApplicationStarter:
         add_all_tracks = AddAllTracks(track_repository)
         clear_all_tracks = ClearAllTracks(track_repository)
         export_counts = self._create_export_counts(
-            event_repository, flow_repository, track_repository
+            event_repository, flow_repository, track_repository, create_events
         )
         OTAnalyticsCli(
             cli_args,
@@ -955,15 +955,17 @@ class ApplicationStarter:
     def _create_filter_element_setting_restorer(self) -> FilterElementSettingRestorer:
         return FilterElementSettingRestorer()
 
+    @staticmethod
     def _create_export_counts(
-        self,
         event_repository: EventRepository,
         flow_repository: FlowRepository,
         track_repository: TrackRepository,
+        create_events: CreateEvents,
     ) -> ExportCounts:
         return ExportTrafficCounting(
             event_repository,
             flow_repository,
+            create_events,
             FilterBySectionEnterEvent(SimpleRoadUserAssigner()),
             SimpleTaggerFactory(track_repository),
             FillZerosExporterFactory(SimpleExporterFactory()),

--- a/tests/OTAnalytics/application/analysis/test_traffic_counting.py
+++ b/tests/OTAnalytics/application/analysis/test_traffic_counting.py
@@ -37,6 +37,7 @@ from OTAnalytics.application.analysis.traffic_counting import (
 from OTAnalytics.application.analysis.traffic_counting_specification import (
     CountingSpecificationDto,
 )
+from OTAnalytics.application.use_cases.create_events import CreateEvents
 from OTAnalytics.domain.event import Event, EventRepository
 from OTAnalytics.domain.flow import Flow, FlowId, FlowRepository
 from OTAnalytics.domain.geometry import DirectionVector2D, ImageCoordinate
@@ -664,6 +665,7 @@ class TestTrafficCounting:
     def test_count_traffic(self) -> None:
         event_repository = Mock(spec=EventRepository)
         flow_repository = Mock(spec=FlowRepository)
+        create_events = Mock(spec=CreateEvents)
         road_user_assigner = Mock(spec=RoadUserAssigner)
         tagger_factory = Mock(spec=TaggerFactory)
         tagger = Mock(spec=Tagger)
@@ -698,6 +700,7 @@ class TestTrafficCounting:
         use_case = ExportTrafficCounting(
             event_repository,
             flow_repository,
+            create_events,
             road_user_assigner,
             tagger_factory,
             exporter_factory,
@@ -707,6 +710,7 @@ class TestTrafficCounting:
 
         event_repository.get_all.assert_called_once()
         flow_repository.get_all.assert_called_once()
+        create_events.assert_called_once()
         road_user_assigner.assign.assert_called_once()
         tagger_factory.create_tagger.assert_called_once_with(counting_specification)
         assignments.tag.assert_called_once_with(tagger)

--- a/tests/OTAnalytics/plugin_ui/test_cli.py
+++ b/tests/OTAnalytics/plugin_ui/test_cli.py
@@ -195,6 +195,7 @@ class TestOTAnalyticsCli:
         export_counts = ExportTrafficCounting(
             event_repository,
             flow_repository,
+            create_events,
             FilterBySectionEnterEvent(SimpleRoadUserAssigner()),
             SimpleTaggerFactory(track_repository),
             FillZerosExporterFactory(SimpleExporterFactory()),


### PR DESCRIPTION
OP#2739