### PR TITLE
bug/3245-count-export-is-calculating-events,-even-if-they-are-already-calculated

### DIFF
--- a/OTAnalytics/application/analysis/traffic_counting.py
+++ b/OTAnalytics/application/analysis/traffic_counting.py
@@ -906,7 +906,8 @@ class ExportTrafficCounting(ExportCounts):
         Args:
             specification (CountingSpecificationDto): specification of the export
         """
-        self._create_events()
+        if self._event_repository.is_empty():
+            self._create_events()
         events = self._event_repository.get_all()
         flows = self._flow_repository.get_all()
         assigned_flows = self._assigner.assign(events, flows)

--- a/OTAnalytics/application/application.py
+++ b/OTAnalytics/application/application.py
@@ -379,7 +379,8 @@ class OTAnalyticsApplication:
             file (Path): File to export the events to
             event_list_exporter (EventListExporter): Exporter building the format
         """
-        self.create_events()
+        if self._datastore._event_repository.is_empty():
+            self.create_events()
         self._datastore.export_event_list_file(file, event_list_exporter)
 
     def get_supported_export_formats(self) -> Iterable[ExportFormat]:

--- a/OTAnalytics/domain/event.py
+++ b/OTAnalytics/domain/event.py
@@ -378,3 +378,7 @@ class EventRepository:
             removed = self._events
             self._events = []
             self._subject.notify(EventRepositoryEvent([], removed))
+
+    def is_empty(self) -> bool:
+        """Whether repository is empty."""
+        return not self._events

--- a/tests/OTAnalytics/domain/test_event.py
+++ b/tests/OTAnalytics/domain/test_event.py
@@ -320,3 +320,9 @@ class TestEventRepository:
         subject.notify.assert_called_with(
             EventRepositoryEvent([], [first_event, second_event])
         )
+
+    def test_is_empty(self) -> None:
+        repository = EventRepository()
+        assert repository.is_empty()
+        repository.add(Mock())
+        assert not repository.is_empty()


### PR DESCRIPTION
Only calculate events when event repository invalidated during exporting events  and counts.

OP#3245