### PR TITLE
feature/3405-reselect-previous-sections-after-warning-for-name-conflict-during-flow-creation

### DIFF
--- a/OTAnalytics/plugin_ui/customtkinter_gui/dummy_viewmodel.py
+++ b/OTAnalytics/plugin_ui/customtkinter_gui/dummy_viewmodel.py
@@ -1152,7 +1152,8 @@ class DummyViewModel(
                 message="To add a flow, a unique name is necessary",
                 initial_position=position,
             )
-            flow_data = self.__get_flow_data(input_values, title, position, section_ids)
+            flow_data[FLOW_NAME] = ""
+            flow_data = self.__get_flow_data(flow_data, title, position, section_ids)
         return flow_data
 
     def __is_flow_name_valid(self, flow_data: dict) -> bool:


### PR DESCRIPTION
OP#3405