### PR TITLE
Fix bug intersecting single detection tracks

### DIFF
--- a/OTAnalytics/application/use_cases/track_repository.py
+++ b/OTAnalytics/application/use_cases/track_repository.py
@@ -49,7 +49,7 @@ class GetTracksWithoutSingleDetections:
 
     def as_dataset(self) -> TrackDataset:
         tracks = self._track_repository.get_all()
-        return tracks.filter_by_min_detection_length(1)
+        return tracks.filter_by_min_detection_length(2)
 
 
 class GetAllTrackIds:

--- a/tests/OTAnalytics/application/use_cases/test_track_repository.py
+++ b/tests/OTAnalytics/application/use_cases/test_track_repository.py
@@ -111,7 +111,7 @@ class TestGetTracksWithoutSingleDetections:
         result_dataset = get_tracks.as_dataset()
         assert result_dataset == expected_dataset
         track_repository.get_all.assert_called_once()
-        dataset.filter_by_min_detection_length.assert_called_once_with(1)
+        dataset.filter_by_min_detection_length.assert_called_once_with(2)
 
     def test_get_as_list(self) -> None:
         track_repository = Mock()


### PR DESCRIPTION
The use case was set up incorrectly, keeping single detection tracks.