### PR TITLE
bug/4102-start-and-endpoints-are-plotted-in-reversed-direction

### DIFF
--- a/OTAnalytics/plugin_prototypes/track_visualization/track_viz.py
+++ b/OTAnalytics/plugin_prototypes/track_visualization/track_viz.py
@@ -671,7 +671,7 @@ class TrackStartEndPointPlotter(MatplotlibPlotterImplementation):
             hue=track.TRACK_CLASSIFICATION,
             data=track_df_start_end,
             style="type",
-            markers=[">", "$x$"],
+            markers={"start": ">", "end": "$x$"},
             legend=self._enable_legend,
             s=15,
             ax=axes,


### PR DESCRIPTION
OP#4102