### PR TITLE
feature/3176-do-not-allow-to-create-flows-with-different-names-but-same-start-and-end-section

### DIFF
--- a/OTAnalytics/application/use_cases/flow_repository.py
+++ b/OTAnalytics/application/use_cases/flow_repository.py
@@ -30,6 +30,11 @@ class AddFlow:
         Args:
             flow (Flow): the flow to be added.
         """
+        self.check_flow_already_exists(flow)
+
+        self._flow_repository.add(flow)
+
+    def check_flow_already_exists(self, flow: Flow) -> None:
         if not self.is_flow_name_valid(flow.name):
             raise FlowAlreadyExists(
                 f"A flow with the name {flow.name} already exists. "
@@ -38,7 +43,17 @@ class AddFlow:
         if not self.is_flow_id_valid(flow.id):
             raise FlowIdAlreadyExists(f"A flow with id {flow.id} already exists.")
 
-        self._flow_repository.add(flow)
+        if self.flow_with_same_start_end_section_exists(flow):
+            raise FlowAlreadyExists(
+                "Flow with same start and end section already exists."
+            )
+
+    def flow_with_same_start_end_section_exists(self, flow: Flow) -> bool:
+        existing_flows = self._flow_repository.get_all()
+        for existing_flow in existing_flows:
+            if existing_flow.start == flow.start and existing_flow.end == flow.end:
+                return True
+        return False
 
     def is_flow_name_valid(self, flow_name: str) -> bool:
         if not flow_name:

--- a/tests/OTAnalytics/application/use_cases/test_flow_repository.py
+++ b/tests/OTAnalytics/application/use_cases/test_flow_repository.py
@@ -9,6 +9,7 @@ from OTAnalytics.application.use_cases.flow_repository import (
     FlowIdAlreadyExists,
 )
 from OTAnalytics.domain.flow import Flow, FlowId, FlowRepository
+from OTAnalytics.domain.section import SectionId
 
 
 @pytest.fixture
@@ -16,6 +17,8 @@ def first_flow() -> Mock:
     flow = Mock(spec=Flow)
     flow.id = FlowId("1")
     flow.name = "first"
+    flow.start = SectionId("section_1")
+    flow.end = SectionId("section_2")
     return flow
 
 
@@ -24,6 +27,8 @@ def second_flow() -> Mock:
     flow = Mock(spec=Flow)
     flow.id = FlowId("2")
     flow.name = "second"
+    flow.start = SectionId("section_3")
+    flow.end = SectionId("section_4")
     return flow
 
 
@@ -72,6 +77,17 @@ class TestAddFlow:
 
         with pytest.raises(FlowIdAlreadyExists):
             use_case(new_section)
+
+    def test_add_flow_fails_with_existing_start_end_section(
+        self, first_flow: Flow, second_flow: Mock, flow_repository: Mock
+    ) -> None:
+        second_flow.name = first_flow.name + "suffix"
+        second_flow.start = first_flow.start
+        second_flow.end = first_flow.end
+
+        use_case = AddFlow(flow_repository)
+        with pytest.raises(FlowAlreadyExists):
+            use_case(second_flow)
 
 
 class TestClearAllFlows:


### PR DESCRIPTION
OP#3176