### PR TITLE
feature/4235-keep-sections-selected-when-selecting-a-flow-and-vice-versa

### DIFF
--- a/OTAnalytics/plugin_ui/customtkinter_gui/dummy_viewmodel.py
+++ b/OTAnalytics/plugin_ui/customtkinter_gui/dummy_viewmodel.py
@@ -613,8 +613,6 @@ class DummyViewModel(
         if self._application.action_state.action_running.get():
             return
 
-        if ids:
-            self._application.set_selected_section([])
         self._application.set_selected_flows(ids)
 
         logger().debug(f"New flows selected in treeview: id={ids}")
@@ -623,8 +621,6 @@ class DummyViewModel(
         if self._application.action_state.action_running.get():
             return
 
-        if ids:
-            self._application.set_selected_flows([])
         self._application.set_selected_section(ids)
 
         logger().debug(f"New line sections selected in treeview: id={ids}")

--- a/OTAnalytics/plugin_ui/customtkinter_gui/dummy_viewmodel.py
+++ b/OTAnalytics/plugin_ui/customtkinter_gui/dummy_viewmodel.py
@@ -1007,15 +1007,10 @@ class DummyViewModel(
             self._draw_arrow_for_selected_flows()
 
     def _get_sections_to_highlight(self) -> list[str]:
+        if self._get_selected_flows():
+            return []
         if selected_section_ids := self.get_selected_section_ids():
             return selected_section_ids
-
-        if selected_flows := self._get_selected_flows():
-            sections_to_highlight = []
-            for flow in selected_flows:
-                sections_to_highlight.append(flow.start.id)
-                sections_to_highlight.append(flow.end.id)
-            return sections_to_highlight
         return []
 
     def _draw_sections(self, sections_to_highlight: list[str]) -> None:

--- a/OTAnalytics/plugin_ui/customtkinter_gui/dummy_viewmodel.py
+++ b/OTAnalytics/plugin_ui/customtkinter_gui/dummy_viewmodel.py
@@ -1007,8 +1007,6 @@ class DummyViewModel(
             self._draw_arrow_for_selected_flows()
 
     def _get_sections_to_highlight(self) -> list[str]:
-        if self._get_selected_flows():
-            return []
         if selected_section_ids := self.get_selected_section_ids():
             return selected_section_ids
         return []


### PR DESCRIPTION
OP#4235
OP#4313