### PR TITLE
bug/4360-use-all-detections-in-pythondetectionparser-to-determine-the-track-classification

### DIFF
--- a/OTAnalytics/plugin_parser/otvision_parser.py
+++ b/OTAnalytics/plugin_parser/otvision_parser.py
@@ -367,7 +367,7 @@ class PythonDetectionParser(DetectionParser):
                     all_detections, key=lambda det: det.occurrence
                 )
                 classification = self._track_classification_calculator.calculate(
-                    detections
+                    all_detections
                 )
                 try:
                     current_track = PythonTrack(

--- a/OTAnalytics/plugin_parser/otvision_parser.py
+++ b/OTAnalytics/plugin_parser/otvision_parser.py
@@ -367,7 +367,7 @@ class PythonDetectionParser(DetectionParser):
                     all_detections, key=lambda det: det.occurrence
                 )
                 classification = self._track_classification_calculator.calculate(
-                    all_detections
+                    sort_dets_by_occurrence
                 )
                 try:
                     current_track = PythonTrack(

--- a/tests/OTAnalytics/plugin_parser/test_otvision_parser.py
+++ b/tests/OTAnalytics/plugin_parser/test_otvision_parser.py
@@ -273,9 +273,17 @@ class TestOttrkParser:
 
 class TestPythonDetectionParser:
     @pytest.fixture
-    def parser(self, mocked_track_repository: Mock) -> PythonDetectionParser:
+    def mocked_classificator(self) -> TrackClassificationCalculator:
+        return Mock(spec=TrackClassificationCalculator)
+
+    @pytest.fixture
+    def parser(
+        self,
+        mocked_track_repository: Mock,
+        mocked_classificator: TrackClassificationCalculator,
+    ) -> PythonDetectionParser:
         return PythonDetectionParser(
-            ByMaxConfidence(),
+            mocked_classificator,
             mocked_track_repository,
         )
 
@@ -313,8 +321,10 @@ class TestPythonDetectionParser:
     def test_parse_tracks(
         self,
         track_builder_setup_with_sample_data: TrackBuilder,
+        mocked_classificator: Mock,
         parser: PythonDetectionParser,
     ) -> None:
+        mocked_classificator.calculate.return_value = "car"
         detections: list[
             dict
         ] = track_builder_setup_with_sample_data.build_serialized_detections()
@@ -336,6 +346,7 @@ class TestPythonDetectionParser:
         self,
         track_builder_setup_with_sample_data: TrackBuilder,
         mocked_track_repository: Mock,
+        mocked_classificator: Mock,
         parser: PythonDetectionParser,
     ) -> None:
         detections: list[
@@ -355,8 +366,7 @@ class TestPythonDetectionParser:
         )
         existing_track = existing_track_builder.build_track()
         merged_classification = "car"
-        classificator = Mock(spec=TrackClassificationCalculator)
-        classificator.calculate.return_value = merged_classification
+        mocked_classificator.calculate.return_value = merged_classification
         mocked_track_repository.get_for.return_value = existing_track
         all_detections = deserialized_detections + existing_track.detections
         merged_track = PythonTrack(
@@ -368,6 +378,7 @@ class TestPythonDetectionParser:
         expected_sorted = PythonTrackDataset.from_list([merged_track])
 
         assert_track_datasets_equal(result_sorted_input, expected_sorted)
+        mocked_classificator.calculate.assert_called_once_with(all_detections)
 
     @pytest.mark.parametrize(
         "track_length_limit",


### PR DESCRIPTION
OP#4360