### PR TITLE
Make use cases GetCurrentVideoPath and GetCurrentFrame be dependent on VisualizationTimeProvider

### DIFF
--- a/OTAnalytics/application/plotting.py
+++ b/OTAnalytics/application/plotting.py
@@ -8,7 +8,6 @@ from OTAnalytics.application.state import (
     ObservableOptionalProperty,
     ObservableProperty,
     Plotter,
-    TrackViewState,
     VideosMetadata,
 )
 from OTAnalytics.domain.track import TrackImage
@@ -282,15 +281,15 @@ class GetCurrentVideoPath:
 
     def __init__(
         self,
-        state: TrackViewState,
+        time_provider: VisualizationTimeProvider,
         videos_metadata: VideosMetadata,
     ) -> None:
-        self._state = state
+        self._time_provider = time_provider
         self._videos_metadata = videos_metadata
 
     def get_video(self) -> Optional[str]:
-        if end_date := self._state.filter_element.get().date_range.end_date:
-            if metadata := self._videos_metadata.get_metadata_for(end_date):
+        if current_time := self._time_provider.get_time():
+            if metadata := self._videos_metadata.get_metadata_for(current_time):
                 return metadata.path
         return None
 
@@ -303,16 +302,16 @@ class GetCurrentFrame:
 
     def __init__(
         self,
-        state: TrackViewState,
+        time_provider: VisualizationTimeProvider,
         videos_metadata: VideosMetadata,
     ) -> None:
-        self._state = state
+        self._time_provider = time_provider
         self._videos_metadata = videos_metadata
 
     def get_frame_number(self) -> int:
-        if end_date := self._state.filter_element.get().date_range.end_date:
-            if metadata := self._videos_metadata.get_metadata_for(end_date):
-                time_in_video = end_date - metadata.start
+        if current_time := self._time_provider.get_time():
+            if metadata := self._videos_metadata.get_metadata_for(current_time):
+                time_in_video = current_time - metadata.start
                 if time_in_video < timedelta(0):
                     return 0
                 if time_in_video > metadata.duration:

--- a/OTAnalytics/plugin_ui/visualization/visualization.py
+++ b/OTAnalytics/plugin_ui/visualization/visualization.py
@@ -82,6 +82,16 @@ MARKER_EVENT_FILTER = "x"
 MARKER_EVENT_FRAME = "o"
 
 
+class FilterStartDateProvider(VisualizationTimeProvider):
+    def __init__(self, state: TrackViewState) -> None:
+        self._state = state
+
+    def get_time(self) -> datetime:
+        if start_date := self._state.filter_element.get().date_range.start_date:
+            return start_date
+        return LONG_IN_THE_PAST
+
+
 class FilterEndDateProvider(VisualizationTimeProvider):
     def __init__(self, state: TrackViewState) -> None:
         self._state = state
@@ -153,10 +163,14 @@ class VisualizationBuilder:
         self._flow_repository = datastore._flow_repository
         self._intersection_repository = intersection_repository
         self._event_repository = datastore._event_repository
-        self._get_current_frame = GetCurrentFrame(track_view_state, videos_metadata)
-        self._get_current_video = GetCurrentVideoPath(track_view_state, videos_metadata)
         self._visualization_time_provider: VisualizationTimeProvider = (
             FilterEndDateProvider(track_view_state)
+        )
+        self._get_current_frame = GetCurrentFrame(
+            self._visualization_time_provider, videos_metadata
+        )
+        self._get_current_video = GetCurrentVideoPath(
+            self._visualization_time_provider, videos_metadata
         )
         self._pandas_data_provider: Optional[PandasDataFrameProvider] = None
         self._pandas_event_data_provider: Optional[PandasDataFrameProvider] = None


### PR DESCRIPTION
As of now the time provided in the use cases is always the end date of the filter element. Since there can be use cases where a specific time within a date range is needed, the VisualizationTimeProvider class is used here.

OP#4920