### PR TITLE
Remove 'Create New Project' Button from UI

### DIFF
--- a/OTAnalytics/plugin_ui/customtkinter_gui/frame_project.py
+++ b/OTAnalytics/plugin_ui/customtkinter_gui/frame_project.py
@@ -175,7 +175,7 @@ class FrameProject(AbstractFrameProject, EmbeddedCTkFrame):
     def set_enabled_general_buttons(self, enabled: bool) -> None:
         new_state = STATE_NORMAL if enabled else STATE_DISABLED
         for button in [
-            self._button_new,
+            # self._button_new,
             self.button_save_as,
             self.button_open,
             self.button_quick_save,

--- a/OTAnalytics/plugin_ui/customtkinter_gui/frame_project.py
+++ b/OTAnalytics/plugin_ui/customtkinter_gui/frame_project.py
@@ -109,12 +109,12 @@ class FrameProject(AbstractFrameProject, EmbeddedCTkFrame):
             place_validation_below=True,
         )
         self._button_frame = EmbeddedCTkFrame(master=self)
-        self._button_new = CTkButton(
-            master=self._button_frame,
-            text="New",
-            width=10,
-            command=self._viewmodel.start_new_project,
-        )
+        # self._button_new = CTkButton(
+        #     master=self._button_frame,
+        #     text="New",
+        #     width=10,
+        #     command=self._viewmodel.start_new_project,
+        # )
         self.button_open = CTkButton(
             master=self._button_frame,
             text="Open...",
@@ -143,7 +143,7 @@ class FrameProject(AbstractFrameProject, EmbeddedCTkFrame):
         )
         for column, button in enumerate(
             [
-                self._button_new,
+                # self._button_new,
                 self.button_open,
                 self.button_save_as,
                 self.button_quick_save,


### PR DESCRIPTION
### Description
- Remove the option to create a new project from the UI temporarily as a hotfix for bug OP#6220.
- The correct implementation for creating a new project will be handled in a future update.