### PR TITLE
bug/6594-only-first-frame-of-video-is-shown

### DIFF
--- a/OTAnalytics/application/state.py
+++ b/OTAnalytics/application/state.py
@@ -281,6 +281,12 @@ class VideosMetadata:
             return metadata
         return None
 
+    def get_by_video_name(self, video_name: str) -> Optional[VideoMetadata]:
+        for metadata in self._metadata.values():
+            if metadata.path == video_name:
+                return metadata
+        return None
+
     @property
     def first_video_start(self) -> Optional[datetime]:
         return self._first_video_start

--- a/OTAnalytics/application/use_cases/load_track_files.py
+++ b/OTAnalytics/application/use_cases/load_track_files.py
@@ -66,6 +66,7 @@ class LoadTrackFiles:
         track_ids, videos = self._track_video_parser.parse(
             file, track_ids, parse_result.video_metadata
         )
+        self._videos_metadata.update(parse_result.video_metadata)
         self._video_repository.add_all(videos)
         self._track_to_video_repository.add_all(track_ids, videos)
         self._track_repository.add_all(parse_result.tracks)
@@ -73,4 +74,3 @@ class LoadTrackFiles:
         self._tracks_metadata.update_detection_classes(
             parse_result.detection_metadata.detection_classes
         )
-        self._videos_metadata.update(parse_result.video_metadata)

--- a/OTAnalytics/plugin_ui/main_application.py
+++ b/OTAnalytics/plugin_ui/main_application.py
@@ -287,7 +287,7 @@ class ApplicationStarter:
         flow_parser = self._create_flow_parser()
         config_parser = OtConfigParser(
             format_fixer=format_fixer,
-            video_parser=self._create_video_parser(),
+            video_parser=self._create_video_parser(VideosMetadata()),
             flow_parser=flow_parser,
         )
 
@@ -337,7 +337,8 @@ class ApplicationStarter:
         flow_repository = self._create_flow_repository()
         intersection_repository = self._create_intersection_repository()
         event_repository = self._create_event_repository()
-        video_parser = self._create_video_parser()
+        videos_metadata = VideosMetadata()
+        video_parser = self._create_video_parser(videos_metadata)
         video_repository = self._create_video_repository()
         track_to_video_repository = self._create_track_to_video_repository()
         datastore = self._create_datastore(
@@ -365,7 +366,6 @@ class ApplicationStarter:
         section_repository.register_section_changed_observer(
             clear_all_intersections.on_section_changed
         )
-        videos_metadata = VideosMetadata()
         layer_groups, layers = self._create_layers(
             datastore,
             intersection_repository,
@@ -1151,8 +1151,8 @@ class ApplicationStarter:
             videos_metadata,
         )
 
-    def _create_video_parser(self) -> VideoParser:
-        return CachedVideoParser(SimpleVideoParser(PyAvVideoReader()))
+    def _create_video_parser(self, videos_metadata: VideosMetadata) -> VideoParser:
+        return CachedVideoParser(SimpleVideoParser(PyAvVideoReader(videos_metadata)))
 
     def _create_video_repository(self) -> VideoRepository:
         return VideoRepository()

--- a/tests/OTAnalytics/application/test_state.py
+++ b/tests/OTAnalytics/application/test_state.py
@@ -369,6 +369,20 @@ class TestVideosMetadata:
 
         assert result is None
 
+    def test_get_by_video_name(
+        self, first_full_metadata: VideoMetadata, second_full_metadata: VideoMetadata
+    ) -> None:
+        target = VideosMetadata()
+        target.update(first_full_metadata)
+        target.update(second_full_metadata)
+        actual = target.get_by_video_name(second_full_metadata.path)
+        assert actual == second_full_metadata
+
+    def test_get_by_video_name_empty(self, first_full_metadata: VideoMetadata) -> None:
+        target = VideosMetadata()
+        actual = target.get_by_video_name(first_full_metadata.path)
+        assert actual is None
+
 
 class TestTracksMetadata:
     @pytest.fixture

--- a/tests/OTAnalytics/application/use_cases/test_load_track_files.py
+++ b/tests/OTAnalytics/application/use_cases/test_load_track_files.py
@@ -54,12 +54,12 @@ class TestLoadTrackFile:
 
         order = MagicMock()
         order.track_parser = track_parser
+        order.videos_metadata = videos_metadata
         order.track_video_parser = track_video_parser
         order.video_repository = video_repository
         order.track_repository = track_repository
         order.track_to_video_repository = track_to_video_repository
         order.tracks_metadata = tracks_metadata
-        order.videos_metadata = videos_metadata
         load_track_file = LoadTrackFiles(
             track_parser,
             track_video_parser,
@@ -79,11 +79,11 @@ class TestLoadTrackFile:
             call.track_video_parser.parse(
                 some_file, [some_track_id], some_video_metadata
             ),
+            call.videos_metadata.update(some_video_metadata),
             call.video_repository.add_all([some_video]),
             call.track_to_video_repository.add_all([some_track_id], [some_video]),
             call.track_repository.add_all(track_dataset_result),
             call.tracks_metadata.update_detection_classes(
                 detection_metadata.detection_classes
             ),
-            call.videos_metadata.update(some_video_metadata),
         ]

--- a/tests/OTAnalytics/plugin_parser/test_streaming_parser.py
+++ b/tests/OTAnalytics/plugin_parser/test_streaming_parser.py
@@ -228,7 +228,7 @@ class TestStreamOttrkParser:
 
         assert tracks_metadata.detection_classifications == expected_detection_classes
 
-        assert list(videos_metadata._metadata.values())[0] == VideoMetadata(
+        assert list(videos_metadata._metadata_by_date.values())[0] == VideoMetadata(
             path="myhostname_file.mp4",
             recorded_start_date=datetime(
                 year=2020,

--- a/tests/OTAnalytics/plugin_ui/test_cli.py
+++ b/tests/OTAnalytics/plugin_ui/test_cli.py
@@ -201,7 +201,7 @@ def mock_flow_parser() -> Mock:
 
 @pytest.fixture
 def video_parser() -> VideoParser:
-    return CachedVideoParser(SimpleVideoParser(PyAvVideoReader()))
+    return CachedVideoParser(SimpleVideoParser(PyAvVideoReader(VideosMetadata())))
 
 
 @pytest.fixture


### PR DESCRIPTION
Introduced a fallback mechanism in `PyAvVideoReader` to retrieve the total frame count from `VideosMetadata` if not available in the video stream. Updated related tests and refactored initialization to ensure `VideosMetadata` is passed where required.

OP#6594