### PR TITLE
bug/6837-pyink-in-super-linter-throws-linting-errors

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -31,6 +31,7 @@ jobs:
           VALIDATE_PYTHON_MYPY: false
           VALIDATE_JSCPD: false
           VALIDATE_PYTHON_BLACK: false
+          VALIDATE_PYTHON_PYINK: false
 
           LINTER_RULES_PATH: /
           PYTHON_FLAKE8_CONFIG_FILE: .flake8


### PR DESCRIPTION
This pull request disables PyInk validation to prevent unnecessary linting errors.

OP#6837