### PR TITLE
Fix GitHub release build configuration

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,7 +1,7 @@
 base_files:
   - "LICENSE"
   - "README.md"
-  - "requirements.txt"
+  - "pyproject.toml"
 configurations:
   - package_path: OTAnalytics
     files:


### PR DESCRIPTION
The pull request addresses an issue with the GitHub release build workflow. The build configuration was updated to work with `uv` as there was a missing `requirements.txt` file causing the workflow to fail.

OP#8492
OP#8493