### PR TITLE
OP#9514: Fix feather file column order mismatch in concat operations

### DIFF
--- a/OTAnalytics/plugin_parser/convert_ottrk_to_feathers.py
+++ b/OTAnalytics/plugin_parser/convert_ottrk_to_feathers.py
@@ -99,6 +99,7 @@ def convert_ottrk_to_feather(input_file: Path) -> None:
 
     # Get the pandas DataFrame
     df = pandas_dataset.get_data()
+    df = df[sorted(df.columns)]
     logger().info(f"DataFrame shape: {df.shape}")
 
     # Save DataFrame to feather format

--- a/OTAnalytics/plugin_parser/feathers_parser.py
+++ b/OTAnalytics/plugin_parser/feathers_parser.py
@@ -137,6 +137,8 @@ class FeathersParser(TrackParser):
             detections_metadata.append(detection_metadata)
         logger().info(f"{len(files)} track files parsed.")
 
+        columns = data_frames[0].columns
+        data_frames = [df.select(columns) for df in data_frames]
         df = pl.concat(data_frames)
         # Create TrackDataset from DataFrame
         calculator = PolarsByMaxConfidence()

--- a/tests/unit/OTAnalytics/plugin_parser/test_feathers_parser.py
+++ b/tests/unit/OTAnalytics/plugin_parser/test_feathers_parser.py
@@ -13,11 +13,13 @@ import polars
 import pytest
 
 from OTAnalytics.application.datastore import DetectionMetadata, TrackParseResult
+from OTAnalytics.domain import track
 from OTAnalytics.domain.video import VideoMetadata
 from OTAnalytics.plugin_datastore.polars_track_store import PolarsTrackDataset
 from OTAnalytics.plugin_datastore.track_geometry_store.polars_geometry_store import (
     PolarsTrackGeometryDataset,
 )
+from OTAnalytics.plugin_parser import ottrk_dataformat as ottrk
 from OTAnalytics.plugin_parser.feathers_parser import FeathersParser
 
 
@@ -279,58 +281,58 @@ class TestFeathersParser:
         """
 
         columns_order_a = [
-            "classification",
-            "confidence",
-            "x",
-            "y",
-            "w",
-            "h",
-            "interpolated_detection",
-            "first",
-            "finished",
-            "frame",  # swapped
-            "video_name",
-            "input_file",
-            "original_track_id",
-            "track_classification",
-            "track_id",
-            "occurrence",
+            track.CLASSIFICATION,
+            track.CONFIDENCE,
+            track.X,
+            track.Y,
+            track.W,
+            track.H,
+            track.INTERPOLATED_DETECTION,
+            ottrk.FIRST,
+            ottrk.FINISHED,
+            track.FRAME,  # swapped
+            track.VIDEO_NAME,
+            track.INPUT_FILE,
+            track.ORIGINAL_TRACK_ID,
+            track.TRACK_CLASSIFICATION,
+            track.TRACK_ID,
+            track.OCCURRENCE,
         ]
         columns_order_b = [
-            "classification",
-            "confidence",
-            "x",
-            "y",
-            "w",
-            "h",
-            "frame",  # swapped
-            "interpolated_detection",
-            "first",
-            "finished",
-            "video_name",
-            "input_file",
-            "track_classification",
-            "original_track_id",
-            "track_id",
-            "occurrence",
+            track.CLASSIFICATION,
+            track.CONFIDENCE,
+            track.X,
+            track.Y,
+            track.W,
+            track.H,
+            track.FRAME,  # swapped
+            track.INTERPOLATED_DETECTION,
+            ottrk.FIRST,
+            ottrk.FINISHED,
+            track.VIDEO_NAME,
+            track.INPUT_FILE,
+            track.TRACK_CLASSIFICATION,
+            track.ORIGINAL_TRACK_ID,
+            track.TRACK_ID,
+            track.OCCURRENCE,
         ]
         row = {
-            "classification": "car",
-            "confidence": 0.9,
-            "x": 100.0,
-            "y": 100.0,
-            "w": 50.0,
-            "h": 80.0,
-            "frame": 1,
-            "interpolated_detection": False,
-            "first": True,
-            "finished": False,
-            "video_name": "test.mp4",
-            "input_file": "test.ottrk",
-            "original_track_id": "1",
-            "track_classification": "car",
-            "track_id": "1",
-            "occurrence": datetime(2023, 1, 1, 10, 0, 0),
+            track.CLASSIFICATION: "car",
+            track.CONFIDENCE: 0.9,
+            track.X: 100.0,
+            track.Y: 100.0,
+            track.W: 50.0,
+            track.H: 80.0,
+            track.FRAME: 1,
+            track.INTERPOLATED_DETECTION: False,
+            ottrk.FIRST: True,
+            ottrk.FINISHED: False,
+            track.VIDEO_NAME: "test.mp4",
+            track.INPUT_FILE: "test.ottrk",
+            track.ORIGINAL_TRACK_ID: "1",
+            track.TRACK_CLASSIFICATION: "car",
+            track.TRACK_ID: "1",
+            track.OCCURRENCE: datetime(2023, 1, 1, 10, 0, 0),
         }
         df_a = polars.DataFrame(row).select(columns_order_a)
         df_b = polars.DataFrame(row).select(columns_order_b)

--- a/tests/unit/OTAnalytics/plugin_parser/test_feathers_parser.py
+++ b/tests/unit/OTAnalytics/plugin_parser/test_feathers_parser.py
@@ -273,6 +273,7 @@ class TestFeathersParser:
         mock_parse_json: Mock,
         parser: FeathersParser,
         sample_metadata: dict[str, Any],
+        test_data_tmp_dir: Path,
     ) -> None:
         """Regression test: parse_files must handle feather files with different
         column orders without raising polars ShapeError.
@@ -340,20 +341,19 @@ class TestFeathersParser:
         mock_parse_json.return_value = sample_metadata
         mock_from_dataframe.return_value = Mock(spec=PolarsTrackDataset)
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            tmpdir_path = Path(tmpdir)
+        tmpdir_path = test_data_tmp_dir
 
-            file_a = tmpdir_path / "file_a.feather"
-            file_b = tmpdir_path / "file_b.feather"
-            df_a.write_ipc(file_a)
-            df_b.write_ipc(file_b)
+        file_a = tmpdir_path / "file_a.feather"
+        file_b = tmpdir_path / "file_b.feather"
+        df_a.write_ipc(file_a)
+        df_b.write_ipc(file_b)
 
-            for stem in ["file_a", "file_b"]:
-                metadata_path = tmpdir_path / f"{stem}_metadata.json"
-                metadata_path.write_text('{"test": "data"}')
+        for stem in ["file_a", "file_b"]:
+            metadata_path = tmpdir_path / f"{stem}_metadata.json"
+            metadata_path.write_text('{"test": "data"}')
 
-            parser.parse_files([file_a, file_b])
+        parser.parse_files([file_a, file_b])
 
-            concat_df = mock_from_dataframe.call_args[0][0]
-            assert concat_df.shape[0] == 2
-            assert set(concat_df.columns) == set(columns_order_a)
+        concat_df = mock_from_dataframe.call_args[0][0]
+        assert concat_df.shape[0] == 2
+        assert set(concat_df.columns) == set(columns_order_a)

--- a/tests/unit/OTAnalytics/plugin_parser/test_feathers_parser.py
+++ b/tests/unit/OTAnalytics/plugin_parser/test_feathers_parser.py
@@ -9,6 +9,7 @@ from typing import Any
 from unittest.mock import Mock, patch
 
 import pandas as pd
+import polars
 import pytest
 
 from OTAnalytics.application.datastore import DetectionMetadata, TrackParseResult
@@ -276,7 +277,6 @@ class TestFeathersParser:
 
         See: https://openproject.platomo.de/work_packages/9514
         """
-        import polars as pl
 
         columns_order_a = [
             "classification",
@@ -332,8 +332,8 @@ class TestFeathersParser:
             "track_id": "1",
             "occurrence": datetime(2023, 1, 1, 10, 0, 0),
         }
-        df_a = pl.DataFrame(row).select(columns_order_a)
-        df_b = pl.DataFrame(row).select(columns_order_b)
+        df_a = polars.DataFrame(row).select(columns_order_a)
+        df_b = polars.DataFrame(row).select(columns_order_b)
 
         mock_parse_json.return_value = sample_metadata
         mock_from_dataframe.return_value = Mock(spec=PolarsTrackDataset)

--- a/tests/unit/OTAnalytics/plugin_parser/test_feathers_parser.py
+++ b/tests/unit/OTAnalytics/plugin_parser/test_feathers_parser.py
@@ -258,3 +258,100 @@ class TestFeathersParser:
 
         assert isinstance(result, DetectionMetadata)
         assert result.detection_classes == frozenset()
+
+    @patch("OTAnalytics.plugin_parser.feathers_parser.parse_json")
+    @patch(
+        "OTAnalytics.plugin_datastore.polars_track_store."
+        "PolarsTrackDataset.from_dataframe"
+    )
+    def test_parse_files_with_different_column_order(
+        self,
+        mock_from_dataframe: Mock,
+        mock_parse_json: Mock,
+        parser: FeathersParser,
+        sample_metadata: dict[str, Any],
+    ) -> None:
+        """Regression test: parse_files must handle feather files with different
+        column orders without raising polars ShapeError.
+
+        See: https://openproject.platomo.de/work_packages/9514
+        """
+        import polars as pl
+
+        columns_order_a = [
+            "classification",
+            "confidence",
+            "x",
+            "y",
+            "w",
+            "h",
+            "interpolated_detection",
+            "first",
+            "finished",
+            "frame",  # swapped
+            "video_name",
+            "input_file",
+            "original_track_id",
+            "track_classification",
+            "track_id",
+            "occurrence",
+        ]
+        columns_order_b = [
+            "classification",
+            "confidence",
+            "x",
+            "y",
+            "w",
+            "h",
+            "frame",  # swapped
+            "interpolated_detection",
+            "first",
+            "finished",
+            "video_name",
+            "input_file",
+            "track_classification",
+            "original_track_id",
+            "track_id",
+            "occurrence",
+        ]
+        row = {
+            "classification": "car",
+            "confidence": 0.9,
+            "x": 100.0,
+            "y": 100.0,
+            "w": 50.0,
+            "h": 80.0,
+            "frame": 1,
+            "interpolated_detection": False,
+            "first": True,
+            "finished": False,
+            "video_name": "test.mp4",
+            "input_file": "test.ottrk",
+            "original_track_id": "1",
+            "track_classification": "car",
+            "track_id": "1",
+            "occurrence": datetime(2023, 1, 1, 10, 0, 0),
+        }
+        df_a = pl.DataFrame(row).select(columns_order_a)
+        df_b = pl.DataFrame(row).select(columns_order_b)
+
+        mock_parse_json.return_value = sample_metadata
+        mock_from_dataframe.return_value = Mock(spec=PolarsTrackDataset)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+
+            file_a = tmpdir_path / "file_a.feather"
+            file_b = tmpdir_path / "file_b.feather"
+            df_a.write_ipc(file_a)
+            df_b.write_ipc(file_b)
+
+            for stem in ["file_a", "file_b"]:
+                metadata_path = tmpdir_path / f"{stem}_metadata.json"
+                metadata_path.write_text('{"test": "data"}')
+
+            parser.parse_files([file_a, file_b])
+
+            concat_df = mock_from_dataframe.call_args[0][0]
+            assert concat_df.shape[0] == 2
+            assert set(concat_df.columns) == set(columns_order_a)


### PR DESCRIPTION
---

### Summary

This pull request addresses column order inconsistencies when processing feather files using `pl.concat`. It includes the following changes:

- **Regression Test**: Introduced a test to reproduce the issue where feather files with mismatched column orders caused `ShapeError` during concatenation.
- **Bug Fix**: Resolved the crash by normalizing column orders:
  - At write time, feather files are now written with columns in alphabetical order.
  - At read time, columns are aligned to match the order of the first file for backwards compatibility.

### Checklist for Review

- [ ] Verify column order normalization is applied correctly at write and read time.
- [ ] Validate that the regression test reproduces the original issue and is resolved by the changes.
- [ ] Confirm that changes do not introduce performance regressions. 

### Additional Context

These changes improve robustness when handling feather files generated from external tools with non-deterministic column orders.

OP#9514