### PR TITLE
OP#10325: Start the web UI when a configuration file is given

### DIFF
--- a/OTAnalytics/plugin_ui/nicegui_application.py
+++ b/OTAnalytics/plugin_ui/nicegui_application.py
@@ -2,6 +2,7 @@ from functools import cached_property
 from typing import Protocol
 
 from OTAnalytics.adapter_ui.ui_factory import UiFactory
+from OTAnalytics.application.logger import logger
 from OTAnalytics.domain.progress import ProgressbarBuilder
 from OTAnalytics.plugin_progress.tqdm_progressbar import TqdmBuilder
 from OTAnalytics.plugin_prototypes.track_visualization.track_viz import (
@@ -103,13 +104,31 @@ class OtAnalyticsNiceGuiApplicationStarter(OtAnalyticsGuiApplicationStarter):
             visualization_filters=self.visualization_filters,
             visualization_layers=self.visualization_layers,
         )
-        self.preload_input_files.load(self.run_config)
+        self.preload_project()
         return NiceguiWebserver(
             page_builders=[main_page_builder],
             layout_components=NiceguiLayoutComponents(),
             hostname=DEFAULT_HOSTNAME,
             port=DEFAULT_PORT,
         )
+
+    def preload_project(self) -> None:
+        """Open the files named on the command line, if any.
+
+        This runs while the webserver is still being built, so anything it
+        raises would otherwise propagate out of startup and the process would
+        die before binding a port -- leaving the user with a traceback instead
+        of an application, over a file they could have opened by hand. The
+        failure is logged and startup continues.
+        """
+        try:
+            self.preload_input_files.load(self.run_config)
+        except Exception as cause:
+            logger().exception(
+                "Could not open the files given on the command line. "
+                "Starting without them.",
+                exc_info=cause,
+            )
 
     @cached_property
     def analysis_form(self) -> AnalysisForm:

--- a/OTAnalytics/plugin_ui/nicegui_gui/pages/visualization_filters_form/container.py
+++ b/OTAnalytics/plugin_ui/nicegui_gui/pages/visualization_filters_form/container.py
@@ -158,6 +158,15 @@ class VisualizationFiltersForm(AbstractFrameFilter, ButtonForm):
         self._button_next_second: ui.button | None = None
         self._button_next_frame: ui.button | None = None
         self._button_next_event: ui.button | None = None
+        # Created by `build()`, which runs when a browser first asks for the
+        # page -- long after `_introduce_to_viewmodel` below makes this form
+        # reachable from the view model. Until then the form exists and has no
+        # widgets, and saying so here is what keeps that window harmless.
+        self._filter_by_date_button: ui.button | None = None
+        self._filter_by_date_button_left: ui.button | None = None
+        self._filter_by_date_button_right: ui.button | None = None
+        self._filter_by_class_button: ui.button | None = None
+        self._label_filter_by_date: ui.label | None = None
         self._introduce_to_viewmodel()
         self._frames_to_skip = 0
         self._seconds_to_skip = 0
@@ -342,40 +351,66 @@ class VisualizationFiltersForm(AbstractFrameFilter, ButtonForm):
     def open_range_dialog(self) -> None:
         self._filter_by_date_popup.open()
 
+    def _date_buttons(self) -> list[ui.button]:
+        """Every date button, or none at all while the form is unbuilt."""
+        return [
+            button
+            for button in (
+                self._filter_by_date_button,
+                self._filter_by_date_button_left,
+                self._filter_by_date_button_right,
+            )
+            if button is not None
+        ]
+
     def set_active_color_on_filter_by_date_button(self) -> None:
+        if self._filter_by_date_button is None:
+            return
         self._filter_by_date_button.props("color=orange")
         # Expose active state for Playwright assertions
         self._filter_by_date_button.props("data-filter-by-date-active=true")
 
     def set_inactive_color_on_filter_by_date_button(self) -> None:
+        if self._filter_by_date_button is None:
+            return
         self._filter_by_date_button.props("color=primary")
         # Expose inactive state for Playwright assertions
         self._filter_by_date_button.props("data-filter-by-date-active=false")
 
     def set_active_color_on_filter_by_class_button(self) -> None:
+        if self._filter_by_class_button is None:
+            return
         self._filter_by_class_button.props("color=orange")
 
     def enable_filter_by_class_button(self) -> None:
+        if self._filter_by_class_button is None:
+            return
         self._filter_by_class_button.enable()
 
     def enable_filter_by_date_button(self) -> None:
-        self._filter_by_date_button.enable()
-        self._filter_by_date_button_left.enable()
-        self._filter_by_date_button_right.enable()
+        for button in self._date_buttons():
+            button.enable()
 
     def set_inactive_color_on_filter_by_class_button(self) -> None:
+        if self._filter_by_class_button is None:
+            return
         self._filter_by_class_button.props("color=primary")
 
     def disable_filter_by_date_button(self) -> None:
         self.set_inactive_color_on_filter_by_date_button()
-        self._filter_by_date_button.disable()
-        self._filter_by_date_button_left.disable()
-        self._filter_by_date_button_right.disable()
+        for button in self._date_buttons():
+            button.disable()
 
     def disable_filter_by_class_button(self) -> None:
+        if self._filter_by_class_button is None:
+            return
         self._filter_by_class_button.disable()
 
     def update_date_range(self, date_range: DateRangeDto) -> None:
+        if self._label_filter_by_date is None:
+            # The range still reaches the view model's state, so the label shows
+            # it as soon as `build()` reads that state. Nothing is lost here.
+            return
         start_date = date_range["start_date"]
         end_date = date_range["end_date"]
 

--- a/tests/unit/OTAnalytics/plugin_ui/nicegui_gui/pages/visualization_filters_form/test_container.py
+++ b/tests/unit/OTAnalytics/plugin_ui/nicegui_gui/pages/visualization_filters_form/test_container.py
@@ -46,6 +46,9 @@ def create_target(given: Given) -> VisualizationFiltersForm:
 
 class TestBeforeThePageIsBuilt:
     def test_introduces_itself_to_the_view_model(self) -> None:
+        """
+        #Requirement https://openproject.platomo.de/wp/10325
+        """
         given = create_given()
 
         target = create_target(given)
@@ -71,12 +74,19 @@ class TestBeforeThePageIsBuilt:
         """Each of these reaches a widget that only `build()` creates. Before
         this fix, `update_date_range` raised `AttributeError` and took the whole
         startup with it.
+
+        #Requirement https://openproject.platomo.de/wp/10325
+
+        @bug by randy-seng
         """
         target = create_target(create_given())
 
         call(target)
 
     def test_offers_no_general_buttons_yet(self) -> None:
+        """
+        #Requirement https://openproject.platomo.de/wp/10325
+        """
         target = create_target(create_given())
 
         assert target.get_general_buttons() == []

--- a/tests/unit/OTAnalytics/plugin_ui/nicegui_gui/pages/visualization_filters_form/test_container.py
+++ b/tests/unit/OTAnalytics/plugin_ui/nicegui_gui/pages/visualization_filters_form/test_container.py
@@ -1,0 +1,82 @@
+"""Tests the form before its page has been built.
+
+The form introduces itself to the view model in `__init__`
+(`_introduce_to_viewmodel`), so the view model can call it from the moment it
+exists. `build()` runs much later, when a browser asks for the page. Anything
+the application does in between -- preloading a `--config` file while the
+webserver is still being constructed, for one -- reaches a form whose widgets
+do not exist yet.
+
+#Requirement https://openproject.platomo.de/wp/10325
+"""
+
+from dataclasses import dataclass
+from unittest.mock import Mock
+
+import pytest
+
+from OTAnalytics.adapter_ui.dto import DateRangeDto
+from OTAnalytics.plugin_ui.nicegui_gui.pages.visualization_filters_form.container import (  # noqa
+    VisualizationFiltersForm,
+)
+
+A_RANGE: DateRangeDto = {"start_date": "2023-05-24", "end_date": "2023-05-25"}
+NO_RANGE: DateRangeDto = {"start_date": "", "end_date": ""}
+
+
+@dataclass
+class Given:
+    resource_manager: Mock
+    view_model: Mock
+
+
+def create_given() -> Given:
+    resource_manager = Mock()
+    resource_manager.get.return_value = "label"
+    view_model = Mock()
+    view_model.get_skip_seconds.return_value = 1
+    view_model.get_skip_frames.return_value = 1
+    return Given(resource_manager=resource_manager, view_model=view_model)
+
+
+def create_target(given: Given) -> VisualizationFiltersForm:
+    """The form as the application first has it: constructed, not yet built."""
+    return VisualizationFiltersForm(given.resource_manager, given.view_model)
+
+
+class TestBeforeThePageIsBuilt:
+    def test_introduces_itself_to_the_view_model(self) -> None:
+        given = create_given()
+
+        target = create_target(given)
+
+        given.view_model.set_filter_frame.assert_called_once_with(target)
+
+    @pytest.mark.parametrize(
+        "call",
+        [
+            lambda form: form.update_date_range(A_RANGE),
+            lambda form: form.update_date_range(NO_RANGE),
+            lambda form: form.enable_filter_by_date_button(),
+            lambda form: form.disable_filter_by_date_button(),
+            lambda form: form.enable_filter_by_class_button(),
+            lambda form: form.disable_filter_by_class_button(),
+            lambda form: form.set_active_color_on_filter_by_date_button(),
+            lambda form: form.set_inactive_color_on_filter_by_date_button(),
+            lambda form: form.set_active_color_on_filter_by_class_button(),
+            lambda form: form.set_inactive_color_on_filter_by_class_button(),
+        ],
+    )
+    def test_the_view_model_can_call_it_without_raising(self, call) -> None:  # type: ignore[no-untyped-def] # noqa: E501
+        """Each of these reaches a widget that only `build()` creates. Before
+        this fix, `update_date_range` raised `AttributeError` and took the whole
+        startup with it.
+        """
+        target = create_target(create_given())
+
+        call(target)
+
+    def test_offers_no_general_buttons_yet(self) -> None:
+        target = create_target(create_given())
+
+        assert target.get_general_buttons() == []

--- a/tests/unit/OTAnalytics/plugin_ui/test_nicegui_preload.py
+++ b/tests/unit/OTAnalytics/plugin_ui/test_nicegui_preload.py
@@ -39,6 +39,9 @@ def create_target(given: Given) -> OtAnalyticsNiceGuiApplicationStarter:
 
 class TestPreloadingTheProject:
     def test_loads_the_files_named_on_the_command_line(self) -> None:
+        """
+        #Requirement https://openproject.platomo.de/wp/10325
+        """
         given = create_given()
 
         create_target(given).preload_project()
@@ -46,6 +49,11 @@ class TestPreloadingTheProject:
         given.preload_input_files.load.assert_called_once_with(given.run_config)
 
     def test_a_file_that_cannot_be_loaded_does_not_stop_the_server(self) -> None:
+        """
+        #Requirement https://openproject.platomo.de/wp/10325
+
+        @bug by randy-seng
+        """
         given = create_given(load_error=FileNotFoundError("no such otconfig"))
 
         create_target(given).preload_project()
@@ -54,6 +62,10 @@ class TestPreloadingTheProject:
         """Deliberately broad: the point is that startup continues, and every
         exception type reaching here has already cost the user their server
         once.
+
+        #Requirement https://openproject.platomo.de/wp/10325
+
+        @bug by randy-seng
         """
         given = create_given(load_error=RuntimeError("anything at all"))
 

--- a/tests/unit/OTAnalytics/plugin_ui/test_nicegui_preload.py
+++ b/tests/unit/OTAnalytics/plugin_ui/test_nicegui_preload.py
@@ -1,0 +1,60 @@
+"""Tests that a file named on the command line cannot stop the server starting.
+
+The web UI preloads `--config` while the webserver is still being constructed,
+so anything the load raises propagates out of startup and the process dies
+before it binds a port. The user is then left with a traceback and no
+application, for a file they could simply have opened again by hand.
+
+#Requirement https://openproject.platomo.de/wp/10325
+"""
+
+from dataclasses import dataclass
+from unittest.mock import Mock
+
+from OTAnalytics.plugin_ui.nicegui_application import (
+    OtAnalyticsNiceGuiApplicationStarter,
+)
+
+
+@dataclass
+class Given:
+    run_config: Mock
+    preload_input_files: Mock
+
+
+def create_given(load_error: Exception | None = None) -> Given:
+    preload_input_files = Mock()
+    if load_error is not None:
+        preload_input_files.load.side_effect = load_error
+    return Given(run_config=Mock(), preload_input_files=preload_input_files)
+
+
+def create_target(given: Given) -> OtAnalyticsNiceGuiApplicationStarter:
+    target = OtAnalyticsNiceGuiApplicationStarter(given.run_config)
+    # The starter builds its own collaborators through cached_property, so
+    # seeding the cache is how one of them is substituted.
+    target.__dict__["preload_input_files"] = given.preload_input_files
+    return target
+
+
+class TestPreloadingTheProject:
+    def test_loads_the_files_named_on_the_command_line(self) -> None:
+        given = create_given()
+
+        create_target(given).preload_project()
+
+        given.preload_input_files.load.assert_called_once_with(given.run_config)
+
+    def test_a_file_that_cannot_be_loaded_does_not_stop_the_server(self) -> None:
+        given = create_given(load_error=FileNotFoundError("no such otconfig"))
+
+        create_target(given).preload_project()
+
+    def test_survives_a_failure_of_any_kind(self) -> None:
+        """Deliberately broad: the point is that startup continues, and every
+        exception type reaching here has already cost the user their server
+        once.
+        """
+        given = create_given(load_error=RuntimeError("anything at all"))
+
+        create_target(given).preload_project()


### PR DESCRIPTION
## What this does

`OTAnalytics --webui --config <file>` never started. The process died before binding a port, with a traceback and no application.

`VisualizationFiltersForm` registers itself with the view model in `__init__`, but its widgets are created in `build()`, which runs only when a browser asks for the page. The `--config` preload runs between those two points — inside the `webserver` property, before any page is built — so it notified a form whose widgets did not exist.

## Notes for the reviewer

The fix is wider than the one crash. **Ten** methods on that form reach a widget created only in `build()`, and each would fail the same way; `update_date_range` was just the one on the preload path. The tests call all ten. That is why "not yet built" became a state the form has — declared `None` in `__init__`, the way the navigation buttons already were — rather than a `hasattr` guard on the single method that happened to crash.

Same family as the bug found while reviewing OP#10321, where `info_box` reached for a browser client in this same startup window.

## Limitation

A **malformed** otconfig still stops startup. `ApplicationStarter.run_config` (`application_starter.py:72`) parses the file to learn the log file and save paths, before any of this exists, and that parse is unguarded. Only failures in the second, preloading load are caught: unreadable tracks, clashing sections, a reference resolving nowhere.
Making an unparseable file survivable means letting `RunConfiguration` be built without one — bigger than this defect, and worth its own ticket.

## Testing

By hand: `python -m OTAnalytics --webui --config project.otconfig` now starts and serves.

Also verified against the blocked case that prompted this — merging this branch into `task/10322` on a throwaway branch makes `tests/acceptance/test_load_from_s3.py` pass against MinIO, 2 of 2. Expect one merge conflict there: slice 6's user-source wipe sits on the lines next to the new `preload_project()` call.

OP#10325
